### PR TITLE
[SP-5] Fix: usePaginatedList next Page

### DIFF
--- a/src/infra/hooks/usePaginatedList.ts
+++ b/src/infra/hooks/usePaginatedList.ts
@@ -21,7 +21,7 @@ export function usePaginatedList<Data>(
     queryKey,
     queryFn: ({pageParam = 1}) => getList(pageParam),
     getNextPageParam: ({meta}) =>
-      meta.hasNextPage ? meta.currentPage + 1 : null,
+      meta.hasNextPage ? meta.currentPage + 1 : undefined,
   });
 
   useEffect(() => {


### PR DESCRIPTION
**Bug:**
The `usePaginatedList` hook continues to fetch the next page even when it doesn't exist.

**Fix:**
The `getNextPageParam` function from `useInfiniteQuery` should return `undefined` to indicate there is no next page available, as per [documentation](https://tanstack.com/query/latest/docs/react/reference/useInfiniteQuery).