### PR TITLE
Use node 18 on Pull Request Checks

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - name: Install Packages
         run: yarn install


### PR DESCRIPTION
The MSW library has an issue with the most recent Node version `20.12.x`, which makes the test fail when trying to access the `server.listen();` method as shown [here](https://github.com/LucasGarcez/NubbleApp/actions/runs/8679108246/job/23797130312#step:7:49). So to pass the tests locally, ensure you are running a compatible node version (>= 18 and <= 20.9.0). 

The PR Checks workflow started to fail on GitHub Actions due to the new runner version `v2.315.0` that enforces node 20, as per this [commit](https://github.com/actions/runner/pull/3192). This PR updates the workflow to enforce the use of node 18 following the same config as per [MSW repo workflows](https://github.com/mswjs/msw/actions/runs/8677606184/workflow).