### PR TITLE
30 - Publicação na Google Play (Android)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ local.properties
 .cxx/
 *.keystore
 !debug.keystore
+*.jks
 
 # node.js
 #

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,7 +92,7 @@ android {
         release {
             storeFile file('upload.jks')
             storePassword System.getenv('NUBBLE_STORE_PASSWORD')
-            keyAlias System.getenv('NUBBLE_ALIAS_PASSWORD')
+            keyAlias System.getenv('NUBBLE_KEY_ALIAS')
             keyPassword System.getenv('NUBBLE_KEY_PASSWORD')
         }
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,9 +74,9 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
     compileSdk rootProject.ext.compileSdkVersion
 
-    namespace "com.nubbleapp"
+    namespace "br.com.coffstack.nubble"
     defaultConfig {
-        applicationId "com.nubbleapp"
+        applicationId "br.com.coffstack.nubble"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,6 +89,12 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        release {
+            storeFile file('upload.jks')
+            storePassword 'upload'
+            keyAlias 'upload'
+            keyPassword 'upload'
+        }
     }
     buildTypes {
         debug {
@@ -97,7 +103,7 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,9 +91,9 @@ android {
         }
         release {
             storeFile file('upload.jks')
-            storePassword 'upload'
-            keyAlias 'upload'
-            keyPassword 'upload'
+            storePassword System.getenv('NUBBLE_STORE_PASSWORD')
+            keyAlias System.getenv('NUBBLE_ALIAS_PASSWORD')
+            keyPassword System.getenv('NUBBLE_KEY_PASSWORD')
         }
     }
     buildTypes {

--- a/android/app/src/main/java/br/com/coffstack/nubble/MainActivity.kt
+++ b/android/app/src/main/java/br/com/coffstack/nubble/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.nubbleapp;
+package br.com.coffstack.nubble;
 import expo.modules.ReactActivityDelegateWrapper
 
 import com.facebook.react.ReactActivity

--- a/android/app/src/main/java/br/com/coffstack/nubble/MainApplication.kt
+++ b/android/app/src/main/java/br/com/coffstack/nubble/MainApplication.kt
@@ -1,4 +1,4 @@
-package com.nubbleapp;
+package br.com.coffstack.nubble;
 import android.content.res.Configuration
 import expo.modules.ApplicationLifecycleDispatcher
 import expo.modules.ReactNativeHostWrapper

--- a/src/api/apiConfig.ts
+++ b/src/api/apiConfig.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
  *
  * i.e: `'http://192.168.20.15:3333/'`
  */
-export const BASE_URL = 'http://127.0.0.1:3333/';
+export const BASE_URL = 'https://nubble-api.coffstack.com.br/';
 export const api = axios.create({
   baseURL: BASE_URL,
 });


### PR DESCRIPTION
## O que você aprenderá:

Nesse módulo você entenderá a fundo o processo de publicar um App Android na Google Play. Desde a criação de conta, preenchendo todos os formulários, até processos complexos como gerar chaves de assinatura para fazer o build dos arquivos APK e AAB. 

Você aprenderá a gerar versões para testes internos que podem ser instaladas no dispositivo dos usuários através da Play Store, antes mesmo da publicação do App! Finalmente, finalizará o módulo aprendendo a enviar o App para revisão do Google e publica-lo em produção.

## **Ao concluir, você será capaz de:**

- Publicar um App Android na Google Play.
- Entender a diferença entre upload key e App signing key.
- Entender a diferença e gerar arquivos APK e AAB.
- Criar grupos de teste interno e testar versões antes de publica-las.
- Configurar variáveis de ambiente e usa-las nos arquivos Gradle.

## Bibliotecas e Recursos:

- Android Studio para geração de chaves de assinatura.
- Gradle CLI (gradlew) para gerar arquivos APK e AAB
- Recursos para gerar capturas de tela (screenshots)