### PR TITLE
Fix RadioButton border radius issue on Android

### DIFF
--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -19,7 +19,7 @@ export function RadioButton({isSelected, onPress}: RadioButtonProps) {
       borderRadius={'s12'}
       borderColor={isSelected ? 'primary' : 'onBackgroundGray2'}>
       <Box
-        backgroundColor={isSelected ? 'primary' : undefined}
+        backgroundColor={isSelected ? 'primary' : 'transparent'}
         height={12}
         width={12}
         borderRadius="s12"

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -17,6 +17,7 @@ export const palette = {
   gray5: '#F5F5F5',
   grayWhite: '#FFFFFF',
   white70: 'rgba(255,255,255,0.7)',
+  transparent: 'transparent',
 };
 
 const lightTheme = {


### PR DESCRIPTION
The `RadioButton` component had a state issue when switching the items in the `RadioButtonSelector`. That happened because the unselected state had an initial `background` as `undefined`.  This PR fixes the issue by starting the unselected state with a transparent color. 

### Before

[android-before.webm](https://github.com/user-attachments/assets/eaddb6ab-a5d9-4163-9017-7d0135942743)


### After

[android-after.webm](https://github.com/user-attachments/assets/0536916f-fefe-478e-bcb5-072819a8e1a5)


